### PR TITLE
 refresh the current wallpaper if config path is already correct

### DIFF
--- a/powershell_scripts/wallpaper_scheduler.ps1
+++ b/powershell_scripts/wallpaper_scheduler.ps1
@@ -97,6 +97,7 @@ Function Wallpaper-Scheduler-Refresh-Wallpaper {
     $current_wallpaper_dir = Split-Path -Path $config.current_wallpaper_path
     
     if (($current_wallpaper_dir -eq $wallpaper_dir) -and -not $force_update) {
+        [WallpaperScheduler]::refresh_wallpaper()
         ECHO "Wallpaper directory is already correct. Aborting."
         return
     }
@@ -133,7 +134,7 @@ Function Wallpaper-Scheduler-Refresh-Wallpaper {
     } else {
         ECHO "No wallpaper found!"
         ECHO "Refreshing wallpaper: FAILED!"
-    }    
+    }
 }
 
 
@@ -187,6 +188,12 @@ class WallpaperScheduler {
 
     static set_wallpaper([String] $filename) {
         Set-ItemProperty -path 'HKCU:\Control Panel\Desktop\' -name wallpaper -value $filename
+        for ($i=0; $i -lt 5; $i++) {
+            rundll32.exe user32.dll, UpdatePerUserSystemParameters
+        }
+    }
+
+    static [Void] refresh_wallpaper() {
         for ($i=0; $i -lt 5; $i++) {
             rundll32.exe user32.dll, UpdatePerUserSystemParameters
         }


### PR DESCRIPTION
### Problem
There seems to be an edge case where invoking UpdatePerUserSystemParameters does not actually update the wallpaper.  This means that the config,current_wallpaper_path gets updated but the wallpaper isn't actually refreshed.  Then the next time `Wallpaper-Scheduler-Refresh-Wallpaper()` is invoked without the $force_update flag, it detects that the config is already correct and doesn't do anything. 

### Proposal
Simple `refresh_wallpaper()` method that invokes UpdatePerUserSystemParameters a bunch of times on the currently set registry values.  This gets run instead of `set_wallpaper()` if we do not want to choose a new wallpaper.
* This should get invoked when the user unlocks their machine and `Wallpaper-Scheduler-Refresh-Wallpaper()` gets triggered.  This should be idempotent if everything is already properly set, but fix the wallpaper if it was not updated for some reason.
